### PR TITLE
Remove dependency on logging

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,16 +27,17 @@
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>log-manager</artifactId>
             <version>237</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-api</artifactId>
+            <scope>runtime</scope>
+            <optional>true</optional>
         </dependency>
 
         <dependency>

--- a/src/main/java/io/airlift/junit/InitializeLogging.java
+++ b/src/main/java/io/airlift/junit/InitializeLogging.java
@@ -13,13 +13,26 @@
  */
 package io.airlift.junit;
 
-import io.airlift.log.Logging;
 import org.junit.jupiter.api.extension.Extension;
 
 public class InitializeLogging
         implements Extension
 {
     static {
-        Logging.initialize();
+        Class<?> loggingClass;
+        try {
+            loggingClass = Class.forName("io.airlift.log.Logging");
+        }
+        catch (ClassNotFoundException ignored) {
+            loggingClass = null;
+        }
+        if (loggingClass != null) {
+            try {
+                loggingClass.getMethod("initialize").invoke(null);
+            }
+            catch (ReflectiveOperationException e) {
+                throw new RuntimeException(e);
+            }
+        }
     }
 }


### PR DESCRIPTION
Allow junit-extensions to be used where logging is not on the classpath. This enables the project to be loaded with surefire's `additionalClasspathDependencies` mechanism, which does not support dependency resolution.